### PR TITLE
Fix tab bar rendering and focus issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,175 @@
+name: Bug Report
+description: Report a bug or issue with SwiftShelf
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the information below to help us diagnose and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the issue you're experiencing...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+      placeholder: Describe what should happen...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+      placeholder: Describe what actually happened...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this issue?
+      options:
+        - Critical (app crashes or unusable)
+        - High (major feature broken)
+        - Medium (feature works but with issues)
+        - Low (minor inconvenience)
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: SwiftShelf Version
+      description: What version of SwiftShelf are you using?
+      placeholder: e.g., 1.0.0 (check Settings > About)
+    validations:
+      required: true
+
+  - type: input
+    id: build-number
+    attributes:
+      label: Build Number
+      description: What build number are you using?
+      placeholder: e.g., 42 (check Settings > About)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: device
+    attributes:
+      label: Apple TV Model
+      description: Which Apple TV are you using? (Check Settings > General > About)
+      options:
+        - Apple TV 4K (3rd generation) Wi-Fi - A2737 (AppleTV14,1) - 2022
+        - Apple TV 4K (3rd generation) Wi-Fi + Ethernet - A2843 (AppleTV14,1) - 2022
+        - Apple TV 4K (2nd generation) - A2169 (AppleTV11,1) - 2021
+        - Apple TV 4K (1st generation) - A1842 (AppleTV6,2) - 2017
+        - Apple TV HD (4th generation) - A1625 (AppleTV5,3) - 2015
+        - Other (specify model number in additional context)
+    validations:
+      required: true
+
+  - type: input
+    id: tvos-version
+    attributes:
+      label: tvOS Version
+      description: Which version of tvOS are you running?
+      placeholder: e.g., 17.5.1 (check Settings > General > About)
+    validations:
+      required: true
+
+  - type: input
+    id: audiobookshelf-version
+    attributes:
+      label: Audiobookshelf Server Version
+      description: What version of Audiobookshelf server are you connecting to?
+      placeholder: e.g., 2.30.0 (check server settings)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: media-type
+    attributes:
+      label: Media Type
+      description: What type of media were you playing when the issue occurred?
+      options:
+        - Audiobook (single file)
+        - Audiobook (multi-file)
+        - Podcast
+        - Ebook (EPUB)
+        - Not applicable
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console Logs (if available)
+      description: |
+        If you can access console logs from Xcode, please paste them here.
+        This will be automatically formatted as code.
+      render: shell
+      placeholder: Paste any relevant console output here...
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem.
+      placeholder: Drag and drop images here or paste image URLs...
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: |
+        Add any other context about the problem here.
+        - Is this reproducible?
+        - Does it happen with specific audiobooks?
+        - Network conditions (WiFi, cellular, VPN)?
+        - Any error messages?
+      placeholder: Any additional information that might be helpful...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      description: Please confirm the following before submitting
+      options:
+        - label: I have searched for existing issues to avoid duplicates
+          required: true
+        - label: I have provided all required information above
+          required: true
+        - label: I can reproduce this issue consistently
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Audiobookshelf Documentation
+    url: https://www.audiobookshelf.org/docs
+    about: Official Audiobookshelf server documentation
+  - name: Audiobookshelf Community
+    url: https://github.com/advplyr/audiobookshelf/discussions
+    about: Ask questions and discuss with the Audiobookshelf community
+  - name: SwiftShelf Discussions
+    url: https://github.com/michaeldvinci/swiftshelf-tvos/discussions
+    about: General questions and discussions about SwiftShelf

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,89 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for SwiftShelf
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe your idea below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: I'm frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like
+      placeholder: I would like to be able to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you've considered
+      placeholder: Another approach could be...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature to you?
+      options:
+        - Critical (blocking my use of the app)
+        - High (would significantly improve my experience)
+        - Medium (nice to have)
+        - Low (minor enhancement)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: feature-type
+    attributes:
+      label: Feature Category
+      description: What type of feature is this?
+      options:
+        - Playback (player controls, seeking, etc.)
+        - Library Management (browsing, searching, etc.)
+        - UI/UX (interface improvements)
+        - Sync/Progress (session tracking, resume points)
+        - Settings/Configuration
+        - Accessibility
+        - Performance
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: |
+        Add any other context, screenshots, or examples about the feature request here.
+        - Does the official Audiobookshelf app have this feature?
+        - Are there similar apps with this feature?
+      placeholder: Any additional information...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      description: Please confirm the following before submitting
+      options:
+        - label: I have searched for existing feature requests to avoid duplicates
+          required: true
+        - label: This feature would benefit other users, not just me
+          required: false

--- a/SwiftShelf/ContentView.swift
+++ b/SwiftShelf/ContentView.swift
@@ -132,18 +132,16 @@ struct ContentView: View {
                     .environmentObject(config)
                     .environmentObject(audioManager)
                     .tabItem {
-                        // Tapping the active library title triggers refresh
-                        Button(action: {
-                            if selectedTabIndex == idx {
-                                vm.refreshToken += 1
-                            } else {
-                                selectedTabIndex = idx
-                            }
-                        }) {
-                            Text(lib.name)
-                        }
+                        // Tab items should not contain interactive buttons on tvOS
+                        Text(lib.name)
                     }
                     .tag(idx)
+                    .onTapGesture {
+                        // Tapping the active library tab triggers refresh
+                        if selectedTabIndex == idx {
+                            vm.refreshToken += 1
+                        }
+                    }
             }
 
             NowPlayingView()

--- a/SwiftShelf/GlobalAudioManager.swift
+++ b/SwiftShelf/GlobalAudioManager.swift
@@ -588,4 +588,3 @@ final class GlobalAudioManager: NSObject, ObservableObject {
         print("[GlobalAudioManager] ⏲️ Periodic timers stopped")
     }
 }
-


### PR DESCRIPTION
Fixes #2

- Removed Button wrapper from `.tabItem {}` in ContentView
- Tab items now use plain Text elements as per tvOS guidelines
- Moved tab refresh logic to `.onTapGesture` modifier
- Eliminates white glow/focus artifacts on tab bar labels
- Fixes inconsistent tab bar rendering across different Apple TV models